### PR TITLE
feat(HEK#30): implementa pagina de error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import ProductsPage from './pages/ProductsPage';
 import RootLayout from './pages/RootLayout';
 import ErrorPage from './pages/ErrorPage';
 import ProductDetailPage from './pages/ProductDetailPage';
+import NotFoundPage from './pages/NotFoundPage'; 
 
 const router = createBrowserRouter([
   {
@@ -13,7 +14,8 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <HomePage /> }, 
       { path: 'products', element: <ProductsPage /> },
-      { path: 'products/:productId', element: <ProductDetailPage /> }
+      { path: 'products/:productId', element: <ProductDetailPage /> },
+      { path: '*', element: <NotFoundPage /> } 
     ],
   },
 ]);

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,27 @@
+import { ButtonBig } from "@/components/ui/Button.styles";
+import { FlexCenter, FlexColumn } from "@/styled-components/Flex.styles";
+import { Section } from "@/styled-components/Section.styles";
+import { Body } from "@/styled-components/Typography.styles";
+import { styled } from "@mui/system";
+
+const ErrorContainer = styled(FlexColumn)({
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: 'calc(var(--spacing-unit) * 2)'
+})
+
+export default function NotFoundPage() {
+  return (
+    <Section>
+      <FlexCenter>
+        <ErrorContainer>
+          <h2>Error 404: Page not found</h2>
+          <Body>The page you are looking for is not found.</Body>
+          <a href="/products">
+            <ButtonBig>Start Shopping</ButtonBig>
+          </a>
+        </ErrorContainer>
+      </FlexCenter>
+    </Section>
+  )
+}


### PR DESCRIPTION
### Este PR implementa la página de error 404: not found para todas las url consultadas que no se encuentren implementadas en la app.

Link a la tarea:
https://ui-internship-wasyluk.atlassian.net/browse/HEK-30

<img width="1918" height="992" alt="image" src="https://github.com/user-attachments/assets/85712280-c731-45a0-8ec7-edd0006f07ce" />

Se implementa la pagina de error como un fallback que ataja cualquier dirección url que no comprenda la lista de children de RootLayout:

<img width="676" height="567" alt="image" src="https://github.com/user-attachments/assets/67a42610-f674-48a1-958f-10dc7121e2ff" />

